### PR TITLE
add n64 core and core support

### DIFF
--- a/backend/examples/load_examples.sh
+++ b/backend/examples/load_examples.sh
@@ -9,12 +9,14 @@ uuid_nes_fceumm=00000000000000000000000000000000
 uuid_snes9x=00000000000000000000000000000001
 uuid_v86_freedos=00000000000000000000000000000002
 uuid_v86_win_31=00000000000000000000000000000003
+uuid_n64=00000000000000000000000000000064
 ../target/debug/gisst-cli environment create --json-file ./records/nes/nes_fceumm_1_52_environment.json
 ../target/debug/gisst-cli environment create --json-file ./records/snes/snes_snes9x_1_62_3_environment.json
 ../target/debug/gisst-cli environment create --json-file ./records/v86/freedos_environment.json --environment-config-string '{"bios":{"url":"seabios.bin"},"vga_bios":{"url":"vgabios.bin"},"fda":{"url":"$CONTENT","async":true}}'
 ../target/debug/gisst-cli environment create --json-file ./records/v86/win_31_environment.json --environment-config-string '{"bios":{"url":"seabios.bin"},"vga_bios":{"url":"vgabios.bin"},"memory_size": 67108864, "hda":{"url":"$CONTENT","async":true}}'
+../target/debug/gisst-cli environment create --json-file ./records/n64/n64_gliden64_environment.json
 
-# Create retroarch.cfg for nes / snes
+# Create retroarch.cfg for nes / snes / n64
 uuid_retro_cfg=00000000000000000000000000000100
 ../target/debug/gisst-cli object create -i --force-uuid $uuid_retro_cfg --role config ./data/nes/retroarch.cfg
 
@@ -33,22 +35,28 @@ get_uuid_from_counter() {
   fi
 }
 
-for work in ./data/*/*.{nes,sfc};
+for work in ./data/*/*.{nes,sfc,z64};
 do
+  folder=$(basename `dirname "$work"`)
   file=$(basename -- "$work")
   base=${file%.*};
   ext=${file##*.};
   work_uuid=$(get_uuid_from_counter)
 
 
-  if [ "$ext" = "nes" ]
+  if [ "$folder" = "nes" ]
   then
     ../target/debug/gisst-cli work create --json-string "{\"work_id\":\"$work_uuid\", \"work_name\":\"$base\", \"work_version\":\"NTSC\",\"work_platform\":\"Nintendo Entertainment System\"}"
     ../target/debug/gisst-cli instance create --json-string "{\"instance_id\":\"$work_uuid\", \"environment_id\":\"$uuid_nes_fceumm\", \"work_id\":\"$work_uuid\"}"
     ../target/debug/gisst-cli link object $uuid_retro_cfg $work_uuid --role config
-  else
+  elif [ "$folder" = "snes" ]
+  then
     ../target/debug/gisst-cli work create --json-string "{\"work_id\":\"$work_uuid\", \"work_name\":\"$base\", \"work_version\":\"NTSC\",\"work_platform\":\"Super Nintendo Entertainment System\"}"
     ../target/debug/gisst-cli instance create --json-string "{\"instance_id\":\"$work_uuid\", \"environment_id\":\"$uuid_snes9x\", \"work_id\":\"$work_uuid\"}"
+  elif [ "$folder" = "n64" ]
+  then
+    ../target/debug/gisst-cli work create --json-string "{\"work_id\":\"$work_uuid\", \"work_name\":\"$base\", \"work_version\":\"NTSC\",\"work_platform\":\"Nintendo 64\"}"
+    ../target/debug/gisst-cli instance create --json-string "{\"instance_id\":\"$work_uuid\", \"environment_id\":\"$uuid_n64\", \"work_id\":\"$work_uuid\"}"
   fi
 
   ../target/debug/gisst-cli object create -i --force-uuid "$work_uuid" --link "$work_uuid" --role content "$work"

--- a/backend/examples/records/n64/n64_gliden64_environment.json
+++ b/backend/examples/records/n64/n64_gliden64_environment.json
@@ -1,0 +1,7 @@
+{
+  "environment_id": "00000000000000000000000000000064",
+  "environment_name": "Nintendo 64",
+  "environment_framework": "retroarch",
+  "environment_core_name": "mupen64plus_next",
+  "environment_core_version": "1.62.3"
+}

--- a/backend/gisst/src/model_enums.rs
+++ b/backend/gisst/src/model_enums.rs
@@ -36,6 +36,7 @@ impl fmt::Display for Framework {
 pub enum Platform {
     NES,
     SNES,
+    N64,
     DOS,
 }
 
@@ -47,6 +48,7 @@ impl FromStr for Platform {
             "Microsoft Disk Operating System" => Ok(Platform::DOS),
             "Nintendo Entertainment System" => Ok(Platform::NES),
             "Super Nintendo Entertainment System" => Ok(Platform::SNES),
+            "Nintendo 64" => Ok(Platform::N64),
             _ => Err("Attempting to convert Platform that does not exist"),
         }
     }

--- a/frontend/frontend-embed/src/libretro_adapter.ts
+++ b/frontend/frontend-embed/src/libretro_adapter.ts
@@ -7,6 +7,7 @@ export interface LibretroModule extends EmscriptenModule, LibretroModuleDef {
 }
 interface LibretroModuleDef {
   startRetroArch(canvas:HTMLCanvasElement, args:string[], initialized_cb:() => void):void;
+  locateFile(path:string,prefix:string):string;
   retroArchSend(msg:string):void;
   retroArchRecv():string|undefined;
   message_queue:[Uint8Array,number][];
@@ -128,12 +129,15 @@ export function loadRetroArch(gisst_root:string, core:string, loaded_cb:(mod:Lib
                 module.FS.init(stdin,stdout,null);
             },
         ],
+        locateFile: function(path, _prefix) {
+            return gisst_root+'/cores/'+path;
+        },
         postRun: [],
         printErr: function(text:string) {
             console.log(text);
         }
     };
-  function instantiate(core_factory:(mod:LibretroModuleDef) => Promise<LibretroModule>) {
+    function instantiate(core_factory:(mod:LibretroModuleDef) => Promise<LibretroModule>) {
         core_factory(module).then(loaded_cb).catch(err => {
             console.error("Couldn't instantiate module", err);
             throw err;

--- a/frontend/frontend-web/src/libretro_adapter.ts
+++ b/frontend/frontend-web/src/libretro_adapter.ts
@@ -7,6 +7,7 @@ export interface LibretroModule extends EmscriptenModule, LibretroModuleDef {
 }
 interface LibretroModuleDef {
   startRetroArch(canvas:HTMLCanvasElement, args:string[], initialized_cb:() => void):void;
+  locateFile(path:string,prefix:string):string;
   retroArchSend(msg:string):void;
   retroArchRecv():string|undefined;
   message_queue:[Uint8Array,number][];
@@ -127,6 +128,9 @@ export function loadRetroArch(gisst_root:string, core:string, loaded_cb:(mod:Lib
                 module.FS.init(stdin,stdout,null);
             },
         ],
+        locateFile: function(path, _prefix) {
+            return gisst_root+'/cores/'+path;
+        },
         postRun: [],
         printErr: function(text:string) {
             console.log(text);


### PR DESCRIPTION
none of the official n64 cores seem to be building properly and I know the emulatorjs folks have put work into getting them running, so you'll need to use forked cores and forked RA to make use of the n64 support.