### PR TITLE
100 better errors in gisstserver

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -1520,6 +1521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,8 +2008,17 @@ checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.3.8",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2010,8 +2029,14 @@ checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2945,11 +2970,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -2958,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2969,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2994,10 +3018,14 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/backend/config/default.toml
+++ b/backend/config/default.toml
@@ -17,3 +17,4 @@ folder_depth = 4
 
 [env]
 default_directive = "gisst_server=debug"
+rust_log = "gisst_server=debug"

--- a/backend/config/default.toml
+++ b/backend/config/default.toml
@@ -14,3 +14,6 @@ listen_port = 3000
 root_folder_path = "./storage"
 temp_folder_path = "./tmp"
 folder_depth = 4
+
+[env]
+default_directive = "gisst_server=debug"

--- a/backend/gisst-server/Cargo.toml
+++ b/backend/gisst-server/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.27.0", features = ["full"] }
 tower = {version="0.4.13",features=["util"]}
 tower-http = { version = "0.4.0", features = ["fs", "trace", "cors"] }
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"]}
 uuid = { version = "1.3.1", features = ["serde", "v4"] }
 gisst = { path = "../gisst" }
 serde_with = {version = "3.3.0", features = ["base64"]}

--- a/backend/gisst-server/src/routes.rs
+++ b/backend/gisst-server/src/routes.rs
@@ -256,7 +256,7 @@ async fn create_image(
         Ok(Json(Image::insert(&mut conn, image).await?))
     } else {
         Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Image,
+            gisst::models::NewRecordError::Image(format!("File with id {} not found in database", image.file_id).to_string()),
         ))
     }
 }
@@ -493,7 +493,7 @@ async fn create_object(
         Ok(Json(Object::insert(&mut conn, object).await?))
     } else {
         Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Object,
+            gisst::models::NewRecordError::Object(format!("File with id {} not found in database", object.file_id).to_string()),
         ))
     }
 }
@@ -587,7 +587,7 @@ async fn create_replay(
         ))
     } else {
         Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Replay,
+            gisst::models::NewRecordError::Replay(format!("File with id {} not found in database", replay.file_id).to_string()),
         ))
     }
 }
@@ -640,7 +640,7 @@ async fn create_save(
         Ok(Json(Save::insert(&mut conn, save).await?))
     } else {
         Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Save,
+            gisst::models::NewRecordError::Save(format!("File with id {} not found in database", save.file_id).to_string()),
         ))
     }
 }
@@ -727,7 +727,7 @@ async fn create_state(
         ))
     } else {
         Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::State,
+            gisst::models::NewRecordError::State(format!("File with id {} not found in database", state.file_id).to_string()),
         ))
     }
 }

--- a/backend/gisst-server/src/serverconfig.rs
+++ b/backend/gisst-server/src/serverconfig.rs
@@ -18,6 +18,9 @@ pub struct ServerConfig {
 
     #[serde(default)]
     pub auth: AuthConfig,
+
+    #[serde(default)]
+    pub env: EnvConfig,
 }
 
 impl ServerConfig {
@@ -29,6 +32,26 @@ impl ServerConfig {
             .add_source(File::with_name("config/local.toml").required(false))
             .add_source(Environment::with_prefix("GISST").separator("__"));
         builder.build()?.try_deserialize()
+    }
+}
+
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EnvConfig {
+    // Default directive is the fallback default for tracing if `rust_log` does not parse
+    // Default directive MUST parse for application to start
+    pub default_directive: String,
+    // RUST_LOG env variable as parsed by EnvFilter in tracing_subscriber
+    // May change this to an environment (dev / test / prod) variable with internal
+    pub rust_log: String,
+}
+
+impl Default for EnvConfig {
+    fn default() -> Self {
+       Self {
+           default_directive: "gisst_server=debug".to_string(),
+           rust_log: "warn,gisst_server=debug,gisst=debug".to_string(),
+       }
     }
 }
 

--- a/backend/gisst/Cargo.toml
+++ b/backend/gisst/Cargo.toml
@@ -22,3 +22,4 @@ async-compression       = { version = "0.4", features = ["tokio", "gzip", "zstdm
 chrono = {version = "0.4.28", features = ["serde"]}
 serde_with = { version = "3.3.0", features = ["base64"] }
 base64 = "0.21.4"
+tracing = "0.1.40"

--- a/backend/gisst/src/models.rs
+++ b/backend/gisst/src/models.rs
@@ -13,54 +13,54 @@ use uuid::Uuid;
 
 #[derive(Debug, thiserror::Error, Serialize)]
 pub enum NewRecordError {
-    #[error("could not insert creator record into database")]
-    Creator,
-    #[error("could not insert environment record into database")]
-    Environment,
-    #[error("could not insert file record into database")]
-    File,
-    #[error("could not insert instance record into database")]
-    Instance,
-    #[error("could not insert image record into database")]
-    Image,
-    #[error("could not insert object record into database")]
-    Object,
-    #[error("could not insert replay record into database")]
-    Replay,
-    #[error("could not insert save record into database")]
-    Save,
-    #[error("could not insert screenshot record into database")]
-    Screenshot,
-    #[error("could not insert state record into database")]
-    State,
-    #[error("could not insert work record into database")]
-    Work,
+    #[error("could not insert creator record into database due to `{0}`")]
+    Creator(String),
+    #[error("could not insert environment record into database due to `{0}`")]
+    Environment(String),
+    #[error("could not insert file record into database due to `{0}`")]
+    File(String),
+    #[error("could not insert instance record into database due to `{0}`")]
+    Instance(String),
+    #[error("could not insert image record into database due to `{0}`")]
+    Image(String),
+    #[error("could not insert object record into database due to `{0}`")]
+    Object(String),
+    #[error("could not insert replay record into database due to `{0}`")]
+    Replay(String),
+    #[error("could not insert save record into database due to `{0}`")]
+    Save(String),
+    #[error("could not insert screenshot record into database due to `{0}`")]
+    Screenshot(String),
+    #[error("could not insert state record into database due to `{0}`")]
+    State(String),
+    #[error("could not insert work record into database due to `{0}`")]
+    Work(String),
 }
 
 #[derive(Debug, thiserror::Error, Serialize)]
 pub enum UpdateRecordError {
-    #[error("could not update creator record in database")]
-    Creator,
-    #[error("could not update environment record in database")]
-    Environment,
-    #[error("could not update file record in database")]
-    File,
-    #[error("could not update instance record into database")]
-    Instance,
-    #[error("could not update image record in database")]
-    Image,
-    #[error("could not update object record in database")]
-    Object,
-    #[error("could not update replay record in database")]
-    Replay,
-    #[error("could not update save record in database")]
-    Save,
-    #[error("could not update screenshot record in database")]
-    Screenshot,
-    #[error("could not update state record in database")]
-    State,
-    #[error("could not update work record in database")]
-    Work,
+    #[error("could not update creator record in database due to `{0}`")]
+Creator(String),
+    #[error("could not update environment record in database due to `{0}`")]
+    Environment(String),
+    #[error("could not update file record in database due to `{0}`")]
+    File(String),
+    #[error("could not update instance record into database due to `{0}`")]
+    Instance(String),
+    #[error("could not update image record in database due to `{0}`")]
+    Image(String),
+    #[error("could not update object record in database due to `{0}`")]
+    Object(String),
+    #[error("could not update replay record in database due to `{0}`")]
+    Replay(String),
+    #[error("could not update save record in database due to `{0}`")]
+    Save(String),
+    #[error("could not update screenshot record in database due to `{0}`")]
+    Screenshot(String),
+    #[error("could not update state record in database due to `{0}`")]
+    State(String),
+    #[error("could not update work record in database due to `{0}`")]
+    Work(String),
 }
 
 // empty_string_as_none taken from axum docs here: https://github.com/tokio-rs/axum/blob/main/examples/query-params-with-empty-strings/src/main.rs
@@ -327,7 +327,7 @@ impl DBModel for Creator {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::Creator)
+        .map_err(|e| NewRecordError::Creator(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, creator: Creator) -> Result<Self, UpdateRecordError> {
@@ -345,7 +345,7 @@ impl DBModel for Creator {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| UpdateRecordError::Creator)
+        .map_err(|e| UpdateRecordError::Creator(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -472,7 +472,7 @@ impl DBModel for File {
         )
             .fetch_one(conn)
             .await
-            .map_err(|_| NewRecordError::File)
+            .map_err(|e| NewRecordError::File(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, file: File) -> Result<Self, UpdateRecordError> {
@@ -493,7 +493,7 @@ impl DBModel for File {
         )
             .fetch_one(conn)
             .await
-            .map_err(|_| UpdateRecordError::File)
+            .map_err(|e| UpdateRecordError::File(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -574,7 +574,7 @@ impl DBModel for Instance {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::Instance)
+        .map_err(|e| NewRecordError::Instance(e.to_string()))
     }
 
     async fn update(
@@ -596,7 +596,7 @@ impl DBModel for Instance {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| UpdateRecordError::Instance)
+        .map_err(|e| UpdateRecordError::Instance(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -771,7 +771,7 @@ impl DBModel for Image {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::Image)
+        .map_err(|e| NewRecordError::Image(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, image: Image) -> Result<Self, UpdateRecordError> {
@@ -790,7 +790,7 @@ impl DBModel for Image {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| UpdateRecordError::Image)
+        .map_err(|e| UpdateRecordError::Image(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -945,7 +945,7 @@ impl DBModel for Environment {
         )
             .fetch_one(conn)
             .await
-            .map_err(|_| NewRecordError::Environment)
+            .map_err(|e| NewRecordError::Environment(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -973,7 +973,7 @@ impl DBModel for Environment {
         )
             .fetch_one(conn)
             .await
-            .map_err(|_| UpdateRecordError::Environment)
+            .map_err(|e| UpdateRecordError::Environment(e.to_string()))
     }
 }
 
@@ -1082,7 +1082,7 @@ impl DBModel for Object {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::Object)
+        .map_err(|e| NewRecordError::Object(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, object: Object) -> Result<Self, UpdateRecordError> {
@@ -1100,7 +1100,7 @@ impl DBModel for Object {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| UpdateRecordError::Object)
+        .map_err(|e| UpdateRecordError::Object(e.to_string()))
     }
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
         sqlx::query!("DELETE FROM object WHERE object_id = $1", id)
@@ -1245,7 +1245,7 @@ impl DBModel for Replay {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::Replay)
+        .map_err(|e| NewRecordError::Replay(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, replay: Replay) -> Result<Self, UpdateRecordError> {
@@ -1267,7 +1267,7 @@ impl DBModel for Replay {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| UpdateRecordError::Replay)
+        .map_err(|e| UpdateRecordError::Replay(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -1413,7 +1413,7 @@ impl DBModel for Save {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::Save)
+        .map_err(|e| NewRecordError::Save(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, save: Save) -> Result<Self, UpdateRecordError> {
@@ -1434,7 +1434,7 @@ impl DBModel for Save {
         )
             .fetch_one(conn)
             .await
-            .map_err(|_| UpdateRecordError::Save)
+            .map_err(|e| UpdateRecordError::Save(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -1617,8 +1617,9 @@ impl DBModel for State {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::State)
+        .map_err(|e| NewRecordError::State(e.to_string()))
     }
+
 
     async fn update(conn: &mut PgConnection, state: State) -> Result<Self, UpdateRecordError> {
         sqlx::query_as!(
@@ -1664,7 +1665,7 @@ impl DBModel for State {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| UpdateRecordError::State)
+        .map_err(|e| UpdateRecordError::State(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -1781,7 +1782,7 @@ impl DBModel for Work {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| NewRecordError::Work)
+        .map_err(|e| NewRecordError::Work(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, work: Work) -> Result<Self, UpdateRecordError> {
@@ -1800,7 +1801,7 @@ impl DBModel for Work {
         )
         .fetch_one(conn)
         .await
-        .map_err(|_| UpdateRecordError::Work)
+        .map_err(|e| UpdateRecordError::Work(e.to_string()))
     }
 
     async fn delete_by_id(conn: &mut PgConnection, id: Uuid) -> sqlx::Result<PgQueryResult> {
@@ -1889,7 +1890,7 @@ impl DBModel for Screenshot {
         )
             .fetch_one(conn)
             .await
-            .map_err(|_| NewRecordError::Screenshot)
+            .map_err(|e| NewRecordError::Screenshot(e.to_string()))
     }
 
     async fn update(conn: &mut PgConnection, model: Self) -> Result<Self, UpdateRecordError> {
@@ -1904,7 +1905,7 @@ impl DBModel for Screenshot {
         )
             .fetch_one(conn)
             .await
-            .map_err(|_| UpdateRecordError::Screenshot)
+            .map_err(|e| UpdateRecordError::Screenshot(e.to_string()))
 
     }
 

--- a/backend/gisst/src/storage.rs
+++ b/backend/gisst/src/storage.rs
@@ -6,7 +6,7 @@ use tokio::{
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 
-use log::info;
+use tracing::debug;
 use std::path::{Component, Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
@@ -106,11 +106,11 @@ impl StorageHandler {
         uuid: Uuid,
         dest_filename: &str,
     ) -> tokio::io::Result<()> {
-        info!("Deleting file with filename: {}", dest_filename);
+        debug!("Deleting file with filename: {}", dest_filename);
         let mut path =
             Path::new(root_path).join(Self::split_uuid_to_path_buf(uuid, folder_depth).as_path());
         path.push(dest_filename);
-        info!("Deleting file at path: {}", path.to_string_lossy());
+        debug!("Deleting file at path: {}", path.to_string_lossy());
         remove_file(path).await
     }
 
@@ -120,10 +120,10 @@ impl StorageHandler {
         file_info: &FileInformation,
     ) -> Result<(), StorageError> {
         let mut path = Self::get_dest_file_path(root_path, file_info);
-        println!("In rename_file, dest_path is {}", path.to_string_lossy());
+        debug!("In rename_file, dest_path is {}", path.to_string_lossy());
 
         path.pop();
-        println!("In rename_file, dest_path is {}", path.to_string_lossy());
+        debug!("In rename_file, dest_path is {}", path.to_string_lossy());
 
         if !path.is_dir() {
             create_dir_all(path.as_path()).await?
@@ -206,7 +206,7 @@ impl StorageHandler {
         let save_filename = Self::get_dest_filename(&hash_string, dest_filename);
 
         path.push(&save_filename);
-        info!("writing path {:?}", path);
+        debug!("writing path {:?}", path);
         let mut file = File::create(&path).await?;
         file.write_all(file_data).await?;
 


### PR DESCRIPTION
Added in some string reporting for new record creation and update errors. Added in basic tracing layer, including changing all current "println!" statements to appropriate trace macros. 

There is now an [env] setting in the config files, you will need to overwrite "rust_log" in your local.toml to change trace reporting. Default is for gisst-server package at the DEBUG level. A local toml with the setting:
`rust_log=warn,gisst_server=debug,gisst=debug,tower_http=debug`

Will give basic reporting and show request / response. Will add new issue to create running log file.