### PR TITLE
146 abolish gissterrorgeneric

### DIFF
--- a/backend/gisst-cli/src/args.rs
+++ b/backend/gisst-cli/src/args.rs
@@ -29,11 +29,11 @@ pub enum GISSTCliError {
     #[error("database error")]
     Sql(#[from] sqlx::Error),
     #[error("gisst new model error")]
-    NewModel(#[from] gisst::models::NewRecordError),
+    NewModel(#[from] gisst::error::RecordSQLError),
     #[error("json parse error")]
     JsonParse(#[from] serde_json::Error),
     #[error("storage error")]
-    Storage(#[from] gisst::storage::StorageError),
+    Storage(#[from] gisst::error::StorageError),
     #[error("configuration error")]
     Config(#[from] config::ConfigError),
     #[error("record not found error")]

--- a/backend/gisst-cli/src/main.rs
+++ b/backend/gisst-cli/src/main.rs
@@ -295,8 +295,6 @@ async fn create_object(
 
 #[allow(dead_code)]
 async fn delete_record<T: DBModel>(d: DeleteRecord, db: PgPool) -> Result<(), GISSTCliError>
-where
-    T: DBModel,
 {
     let mut conn = db.acquire().await?;
     T::delete_by_id(&mut conn, d.id)

--- a/backend/gisst-server/src/auth.rs
+++ b/backend/gisst-server/src/auth.rs
@@ -136,7 +136,7 @@ impl User {
         )
             .fetch_one(conn)
             .await
-            .map_err(|e| GISSTError::SqlError(e))
+            .map_err( GISSTError::SqlError )
     }
 
     async fn update(conn: &mut PgConnection, model: &User) -> Result<Self, GISSTError> {
@@ -179,7 +179,7 @@ impl User {
         )
         .fetch_one(conn)
         .await
-        .map_err(|e| GISSTError::SqlError(e))
+        .map_err(GISSTError::SqlError)
     }
 }
 
@@ -237,7 +237,7 @@ pub async fn oauth_callback_handler(
     debug!("Getting db connection");
 
     let user = auth_get_user(state.pool, &profile, token.access_token().secret()).await?;
-    auth.login(&user).await.map_err(|e| GISSTError::AuthUserSerdeLoginError(e))?;
+    auth.login(&user).await?;
     info!("Logged in the user: {user:?}");
     Ok(Redirect::to("/instances"))
 }

--- a/backend/gisst-server/src/auth.rs
+++ b/backend/gisst-server/src/auth.rs
@@ -330,7 +330,7 @@ pub async fn login_handler(
 ) -> Result<impl IntoResponse, GISSTError> {
     let dummy = OpenIDUserInfo::test_user();
     let user = auth_get_user(state.pool, &dummy, "verysecret").await?;
-    auth.login(&user).await.map_err(|e| GISSTError::AuthUserSerdeLoginError(e))?;
+    auth.login(&user).await.map_err(GISSTError::AuthUserSerdeLoginError)?;
     debug!("Logged in the user: {user:?}");
     Ok(Redirect::to("/instances"))
 }

--- a/backend/gisst-server/src/error.rs
+++ b/backend/gisst-server/src/error.rs
@@ -1,58 +1,96 @@
 use axum::{
-    extract::{multipart::MultipartError, Json},
+    extract::{multipart::MultipartError,},
     http::StatusCode,
-    response::{IntoResponse, Response},
-};
-use gisst::models;
-use serde_json::json;
-use thiserror::Error;
+    response::{IntoResponse, Response, Html},
 
-#[derive(Debug, Error)]
+};
+
+use minijinja::{context, Environment};
+use std::{fmt::Debug};
+use std::error::Error;
+use uuid::Uuid;
+use gisst::error::ErrorTable;
+
+#[derive(thiserror::Error)]
 pub enum GISSTError {
     #[error("database error")]
     SqlError(#[from] sqlx::Error),
     #[error("storage error")]
-    StorageError(#[from] gisst::storage::StorageError),
+    StorageError(#[from] gisst::error::StorageError),
     #[error("file not found")]
     FileNotFoundError,
     #[error("IO error")]
     IO(#[from] std::io::Error),
-    #[error("record creation error")]
-    RecordCreateError(#[from] models::NewRecordError),
-    #[error("record creation error")]
-    RecordUpdateError(#[from] models::UpdateRecordError),
+    #[error("error with record SQL manipulation")]
+    RecordManipulationError(#[from] gisst::error::RecordSQLError),
+    #[error("{} record with uuid {} is missing", .table, .uuid)]
+    RecordMissingError {
+        table: ErrorTable,
+        uuid: Uuid,
+    },
     #[error("path prefix error")]
     PathPrefixError(#[from] std::path::StripPrefixError),
     #[error("tokio task error")]
     JoinError(#[from] tokio::task::JoinError),
     #[error("reqwest error")]
     ReqwestError(#[from] reqwest::Error),
-    #[error("auth error")]
-    AuthError(#[from] AuthError),
-    #[error("minijinja error")]
+    #[error("error rendering minijinja template")]
     MiniJinjaError(#[from] minijinja::Error),
-    #[error("generic error")]
-    Generic,
+    #[error("user login error")]
+    AuthUserSerdeLoginError(#[from] serde_json::Error),
+    #[error("missing user auth profile information: {}", .field)]
+    AuthMissingProfileInfoError{ field: String },
+    #[error("incorrect mimetype for request")]
+    MimeTypeError,
+    #[error("user not logged in")]
+    UserNotAuthenticatedError,
+    #[error("error linking uuid: {} to {} reference", .table, .uuid)]
+    RecordLinkingError{
+        table: ErrorTable,
+        uuid: Uuid,
+    },
+    #[error("multipart request error")]
+    MultipartError(#[from] MultipartError),
+    #[error("this should not be reachable!")]
+    Unreachable,
 }
 
-#[derive(Debug, Error)]
-pub enum AuthError {
-    #[error("user creation error")]
-    UserCreateError,
-    #[error("user update error")]
-    UserUpdateError,
+impl Debug for GISSTError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", self)?;
+        if let Some(source) = self.source() {
+            writeln!(f, "Caused by:\n\t{}", source)?;
+        }
+        Ok(())
+    }
 }
 
 impl IntoResponse for GISSTError {
     fn into_response(self) -> Response {
+        let mut env = Environment::new();
+        env.add_template("error.html", r#"
+
+        <div id="embedExample" style="width:320px; height: 280px"></div>
+        <h1>{{status_code }}</h1>
+        <p>Oops! We've encountered a {{ status_code }}, please go back to the previous page while we sort this out.</p>
+        <h2> Cryptic Error Message </h2>
+        <p>{{ message }}</p>
+        <link rel="stylesheet" href="/embed/style.css">
+        <script type="module">
+            import {embed} from '/embed/embed.js';
+            embed("https://gisst.pomona.edu/data/62f78345-b4b0-458d-a6ea-5c08724a6415?state=e32b9c0f-f56e-4a84-b2e6-e4996a82e35a", document.getElementById("embedExample"));
+        </script>
+        "#).unwrap();
+        let error_template = env.get_template("error.html").unwrap();
         let (status, message) = match self {
             GISSTError::SqlError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "database error"),
             GISSTError::IO(_) => (StatusCode::INTERNAL_SERVER_ERROR, "IO error"),
             GISSTError::StorageError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "storage error"),
-            GISSTError::RecordCreateError(_) => {
+            GISSTError::RecordManipulationError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "record manipulation error"),
+            GISSTError::RecordLinkingError{..} => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "record creation error")
             },
-            GISSTError::RecordUpdateError(_) => {
+            GISSTError::RecordMissingError{..} => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "record update error")
             },
             GISSTError::PathPrefixError(_) => {
@@ -63,19 +101,17 @@ impl IntoResponse for GISSTError {
             GISSTError::ReqwestError(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "oauth reqwest error")
             },
-            GISSTError::AuthError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "auth error"),
+            GISSTError::AuthUserSerdeLoginError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "auth error"),
+            GISSTError::AuthMissingProfileInfoError{..} => (StatusCode::INTERNAL_SERVER_ERROR, "auth error, missing profile field"),
+            GISSTError::UserNotAuthenticatedError => (StatusCode::INTERNAL_SERVER_ERROR, "auth error"),
             GISSTError::MiniJinjaError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "minijinja error"),
-            GISSTError::Generic => (StatusCode::INTERNAL_SERVER_ERROR, "generic error"),
+            GISSTError::MimeTypeError => (StatusCode::INTERNAL_SERVER_ERROR, "incompatible mimetype for request"),
+            GISSTError::MultipartError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "multipart request error"),
+            GISSTError::Unreachable => (StatusCode::INTERNAL_SERVER_ERROR, "uh oh error"),
         };
 
-        let body = Json(json!({ "error": message }));
+        let body = Html(error_template.render(context!(status_code => status.clone().to_string(), message => message)).unwrap());
 
         (status, body).into_response()
-    }
-}
-
-impl From<MultipartError> for GISSTError {
-    fn from(_error: MultipartError) -> Self {
-        GISSTError::Generic
     }
 }

--- a/backend/gisst-server/src/routes.rs
+++ b/backend/gisst-server/src/routes.rs
@@ -155,7 +155,7 @@ async fn get_single_creator(
         Ok(
             (if accept.is_none() || accept.as_ref().is_some_and(|hv| hv.contains("text/html")) {
                 let creator_page = app_state.templates
-                    .get_template("creator_all_listing.html").map_err(|e| GISSTError::MiniJinjaError(e))?;
+                    .get_template("creator_all_listing.html")?;
                 Html(
                     creator_page.render(
                         context!(
@@ -366,7 +366,7 @@ async fn get_instances(
 
     Ok(
         (if accept.is_none() || accept.as_ref().is_some_and(|hv| hv.contains("text/html")) {
-            let instance_listing = app_state.templates.get_template("instance_listing.html").unwrap();
+            let instance_listing = app_state.templates.get_template("instance_listing.html")?;
             Html(
                 instance_listing.render(
                     context!(
@@ -443,7 +443,7 @@ async fn get_all_for_instance(
 
         Ok(
             (if accept.is_none() || accept.as_ref().is_some_and(|hv| hv.contains("text/html")) {
-                let instance_all_listing = app_state.templates.get_template("instance_all_listing.html").unwrap();
+                let instance_all_listing = app_state.templates.get_template("instance_all_listing.html")?;
                 Html(
                     instance_all_listing.render(
                         context!(

--- a/backend/gisst-server/src/routes.rs
+++ b/backend/gisst-server/src/routes.rs
@@ -18,6 +18,7 @@ use minijinja::{context, };
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use uuid::Uuid;
+use gisst::error::ErrorTable;
 
 // Nested Router structs for easier reading and manipulation
 
@@ -153,7 +154,8 @@ async fn get_single_creator(
 
         Ok(
             (if accept.is_none() || accept.as_ref().is_some_and(|hv| hv.contains("text/html")) {
-                let creator_page = app_state.templates.get_template("creator_all_listing.html").unwrap();
+                let creator_page = app_state.templates
+                    .get_template("creator_all_listing.html").map_err(|e| GISSTError::MiniJinjaError(e))?;
                 Html(
                     creator_page.render(
                         context!(
@@ -169,12 +171,15 @@ async fn get_single_creator(
             {
                 Json(creator_results).into_response()
             } else {
-                Err(GISSTError::Generic)?
+                Err(GISSTError::MimeTypeError)?
             })
                 .into_response()
         )
     } else {
-        Err(GISSTError::Generic)
+        Err(GISSTError::RecordMissingError {
+            table: ErrorTable::Creator,
+            uuid: id,
+        })
     }
 }
 
@@ -254,9 +259,7 @@ async fn edit_environment(
 ) -> Result<Json<Environment>, GISSTError> {
     let mut conn = app_state.pool.acquire().await?;
     Ok(Json(
-        Environment::update(&mut conn, environment)
-            .await
-            .map_err(GISSTError::RecordUpdateError)?,
+        Environment::update(&mut conn, environment).await?
     ))
 }
 
@@ -293,9 +296,10 @@ async fn create_image(
     if File::get_by_id(&mut conn, image.file_id).await?.is_some() {
         Ok(Json(Image::insert(&mut conn, image).await?))
     } else {
-        Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Image(format!("File with id {} not found in database", image.file_id).to_string()),
-        ))
+        Err(GISSTError::RecordMissingError {
+            table: ErrorTable::File,
+            uuid: image.file_id
+        })
     }
 }
 
@@ -313,9 +317,7 @@ async fn edit_image(
 ) -> Result<Json<Image>, GISSTError> {
     let mut conn = app_state.pool.acquire().await?;
     Ok(Json(
-        Image::update(&mut conn, image)
-            .await
-            .map_err(GISSTError::RecordUpdateError)?,
+        Image::update(&mut conn, image).await?
     ))
 }
 
@@ -380,7 +382,7 @@ async fn get_instances(
         {
             Json(instances).into_response()
         } else {
-            Err(GISSTError::Generic)?
+            Err(GISSTError::MimeTypeError)?
         })
         .into_response(),
     )
@@ -457,12 +459,15 @@ async fn get_all_for_instance(
             {
                 Json(full_instance).into_response()
             } else {
-                Err(GISSTError::Generic)?
+                Err(GISSTError::MimeTypeError)?
             })
             .into_response(),
         )
     } else {
-        Err(GISSTError::Generic)
+        Err(GISSTError::RecordMissingError {
+            table: ErrorTable::Instance,
+            uuid: id,
+        })
     }
 }
 
@@ -530,9 +535,10 @@ async fn create_object(
     if File::get_by_id(&mut conn, object.file_id).await?.is_some() {
         Ok(Json(Object::insert(&mut conn, object).await?))
     } else {
-        Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Object(format!("File with id {} not found in database", object.file_id).to_string()),
-        ))
+        Err(GISSTError::RecordMissingError {
+            table: ErrorTable::File,
+            uuid: object.file_id
+        })
     }
 }
 
@@ -604,6 +610,7 @@ async fn create_replay(
     auth: AuthContext,
     Json(replay): Json<CreateReplay>,
 ) -> Result<Json<Replay>, GISSTError> {
+
     let mut conn = app_state.pool.acquire().await?;
 
     if File::get_by_id(&mut conn, replay.file_id).await?.is_some() {
@@ -615,7 +622,7 @@ async fn create_replay(
                     replay_name: replay.replay_name,
                     replay_description: replay.replay_description,
                     instance_id: replay.instance_id,
-                    creator_id: auth.current_user.ok_or(GISSTError::Generic)?.creator_id,
+                    creator_id: auth.current_user.ok_or(GISSTError::UserNotAuthenticatedError)?.creator_id,
                     replay_forked_from: replay.replay_forked_from,
                     file_id: replay.file_id,
                     created_on: chrono::Utc::now(),
@@ -624,9 +631,10 @@ async fn create_replay(
             .await?,
         ))
     } else {
-        Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Replay(format!("File with id {} not found in database", replay.file_id).to_string()),
-        ))
+        Err(GISSTError::RecordMissingError {
+            table: ErrorTable::File,
+            uuid: replay.file_id,
+        })?
     }
 }
 // Save method handlers
@@ -677,9 +685,10 @@ async fn create_save(
     if File::get_by_id(&mut conn, save.file_id).await?.is_some() {
         Ok(Json(Save::insert(&mut conn, save).await?))
     } else {
-        Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::Save(format!("File with id {} not found in database", save.file_id).to_string()),
-        ))
+        Err(GISSTError::RecordMissingError {
+            table: ErrorTable::File,
+            uuid: save.file_id,
+        })?
     }
 }
 // State method handlers
@@ -755,7 +764,7 @@ async fn create_state(
                     state_description: state.state_description,
                     screenshot_id: state.screenshot_id,
                     replay_id: state.replay_id,
-                    creator_id: auth.current_user.ok_or(GISSTError::Generic)?.creator_id,
+                    creator_id: auth.current_user.ok_or(GISSTError::UserNotAuthenticatedError)?.creator_id,
                     state_replay_index: state.state_replay_index,
                     state_derived_from: state.state_derived_from,
                     created_on: chrono::Utc::now(),
@@ -764,9 +773,10 @@ async fn create_state(
             .await?,
         ))
     } else {
-        Err(GISSTError::RecordCreateError(
-            gisst::models::NewRecordError::State(format!("File with id {} not found in database", state.file_id).to_string()),
-        ))
+        Err(GISSTError::RecordMissingError {
+            table: ErrorTable::File,
+            uuid: state.file_id,
+        })?
     }
 }
 

--- a/backend/gisst-server/src/server.rs
+++ b/backend/gisst-server/src/server.rs
@@ -391,10 +391,8 @@ async fn get_about(
     Ok(Html(
         app_state
             .templates
-            .get_template("about.html")
-            .unwrap()
-            .render(context!())
-            .unwrap(),
+            .get_template("about.html")?
+            .render(context!())?,
     )
     .into_response())
 }
@@ -404,10 +402,8 @@ async fn get_homepage(
     Ok(Html(
         app_state
             .templates
-            .get_template("index.html")
-            .unwrap()
-            .render(context!())
-            .unwrap(),
+            .get_template("index.html")?
+            .render(context!())?,
     )
     .into_response())
 }
@@ -498,8 +494,7 @@ async fn get_player(
         Html(
             app_state
                 .templates
-                .get_template("player.html")
-                .unwrap()
+                .get_template("player.html")?
                 .render(context!(
                     player_params => PlayerTemplateInfo {
                         environment,

--- a/backend/gisst-server/src/tus.rs
+++ b/backend/gisst-server/src/tus.rs
@@ -226,7 +226,7 @@ pub async fn tus_creation(
 
     let metadata = metadata.unwrap();
     for key in ["filename", "hash"].iter() {
-        if metadata.get(&key.to_string()).is_none() {
+        if !metadata.contains_key(*key) {
             return Ok((
                 StatusCode::BAD_REQUEST,
                 format!(

--- a/backend/gisst/src/error.rs
+++ b/backend/gisst/src/error.rs
@@ -55,7 +55,7 @@ impl fmt::Display for ErrorTable {
             ErrorTable::Screenshot => "screenshot",
             ErrorTable::State => "state",
             ErrorTable::Users => "users",
-            ErrorTable::Work => "users",
+            ErrorTable::Work => "work",
         };
         write!(f, "{}", s)
     }

--- a/backend/gisst/src/error.rs
+++ b/backend/gisst/src/error.rs
@@ -1,0 +1,86 @@
+use std::fmt;
+use std::fmt::Formatter;
+
+#[derive(Debug)]
+pub enum ErrorAction {
+    Insert,
+    Update,
+    Select,
+    Delete,
+}
+
+impl fmt::Display for ErrorAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            ErrorAction::Insert => "insert",
+            ErrorAction::Update => "update",
+            ErrorAction::Select => "select",
+            ErrorAction::Delete => "delete",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Debug)]
+pub enum ErrorTable {
+    Creator,
+    Environment,
+    EnvironmentImage,
+    File,
+    Image,
+    Instance,
+    InstanceObject,
+    Object,
+    Replay,
+    Save,
+    Screenshot,
+    State,
+    Users,
+    Work,
+}
+
+impl fmt::Display for ErrorTable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match self {
+            ErrorTable::Creator => "creator",
+            ErrorTable::Environment => "environment",
+            ErrorTable::EnvironmentImage => "environment_image",
+            ErrorTable::File => "file",
+            ErrorTable::Image => "image",
+            ErrorTable::Instance => "instance",
+            ErrorTable::InstanceObject => "instance_object",
+            ErrorTable::Object => "object",
+            ErrorTable::Replay => "replay",
+            ErrorTable::Save => "save",
+            ErrorTable::Screenshot => "screenshot",
+            ErrorTable::State => "state",
+            ErrorTable::Users => "users",
+            ErrorTable::Work => "users",
+        };
+        write!(f, "{}", s)
+    }
+}
+#[derive(thiserror::Error, Debug)]
+pub struct RecordSQLError {
+    pub table: ErrorTable,
+    pub action: ErrorAction,
+    pub source: sqlx::Error,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("IO error")]
+    IO(#[from] std::io::Error),
+    #[error("tokio task error")]
+    JoinError(#[from] tokio::task::JoinError),
+    #[error("path prefix error")]
+    PathPrefixError(#[from] std::path::StripPrefixError),
+    #[error("Storage file not found")]
+    FileNotFoundError,
+}
+
+impl fmt::Display for RecordSQLError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} failed in table {}", self.table, self.action)
+    }
+}

--- a/backend/gisst/src/lib.rs
+++ b/backend/gisst/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod model_enums;
 pub mod models;
 pub mod storage;
+
+pub mod error;

--- a/backend/gisst/src/storage.rs
+++ b/backend/gisst/src/storage.rs
@@ -12,19 +12,8 @@ use tokio::io::AsyncWriteExt;
 
 use bytes::Bytes;
 use uuid::Uuid;
+use crate::error::StorageError;
 
-use thiserror::Error;
-#[derive(Debug, Error)]
-pub enum StorageError {
-    #[error("IO error")]
-    IO(#[from] std::io::Error),
-    #[error("tokio task error")]
-    JoinError(#[from] tokio::task::JoinError),
-    #[error("path prefix error")]
-    PathPrefixError(#[from] std::path::StripPrefixError),
-    #[error("Storage file not found")]
-    FileNotFoundError,
-}
 
 pub struct StorageHandler;
 

--- a/backend/ingest/src/main.rs
+++ b/backend/ingest/src/main.rs
@@ -56,9 +56,9 @@ pub enum IngestError {
     #[error("nul error")]
     Nul(#[from] std::ffi::NulError),
     #[error("storage error")]
-    Storage(#[from] gisst::storage::StorageError),
+    Storage(#[from] gisst::error::StorageError),
     #[error("new record")]
-    NewRecord(#[from] gisst::models::NewRecordError),
+    NewRecord(#[from] gisst::error::RecordSQLError),
     #[error("directory traversal error")]
     Directory(#[from] walkdir::Error),
     #[error("rdb open error")]


### PR DESCRIPTION
Added in an error status page to replace the JSON output

Reorganized error messages, including providing more information on error source

Changed "unwrap" to "?" or "map_err" as appropriate. (There may be more to change now that I think on this.) Some "map_err" calls can probably just be ? now.

Removed GISSTError::Generic, all errors are now named explicitly

Will need to organize a flag / error manager to handle dev / prod settings, maybe dispatching to an error handler? 