### PR TITLE
Fix data type for FFI call to rdb functions during ingest

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "env_logger",
  "gisst",
  "log",
+ "md-5",
  "rdb-sys",
  "serde",
  "serde_json",

--- a/backend/ingest/Cargo.toml
+++ b/backend/ingest/Cargo.toml
@@ -23,3 +23,4 @@ anyhow = "1.0.70"
 gisst = { path = "../gisst" }
 rdb-sys = { path = "../rdb-sys" }
 chrono = { version = "0.4.28", features = ["clock"]}
+md-5                    = "0.10"


### PR DESCRIPTION
I changed hash generation in storage.rs from producing a number to producing a string, but this code actually needs a hash---and specifically an MD5 hash.  So I copied some code. 