### PR TITLE
use new RA flags for audioworklet driver

### DIFF
--- a/dist-update.sh
+++ b/dist-update.sh
@@ -112,7 +112,7 @@ for f in *; do
     fi
     pushd ../ra
     cp libretro_emscripten.bc libretro_emscripten.a
-    emmake make -f Makefile.emscripten LIBRETRO=$f HAVE_THREADS=1 PTHREAD_POOL_SIZE=4 PROXY_TO_PTHREAD=1 HAVE_WASMFS=1 HAVE_EGL=0 ASYNC=$ASYNC SYMBOLS=1 HAVE_OPENGLES3=1 -j all || die "could not build RA dist for ${f}"
+    emmake make -f Makefile.emscripten LIBRETRO=$f HAVE_THREADS=1 PTHREAD_POOL_SIZE=4 PROXY_TO_PTHREAD=1 HAVE_WASMFS=1 HAVE_EXTRA_WASMFS=1 HAVE_EGL=0 HAVE_AL=0 HAVE_AUDIOWORKLET=1 ASYNC=$ASYNC SYMBOLS=1 HAVE_OPENGLES3=1 -j all || die "could not build RA dist for ${f}"
     cp ${f}_libretro.* ../cores
     popd
     popd


### PR DESCRIPTION
This relies on https://github.com/libretro/RetroArch/pull/17750 , but once that PR is merged this can go in as a drop-in faster RA build.