### PR TITLE
Non-destructive upgrade env command

### DIFF
--- a/backend/.sqlx/query-1d52e5fb9a93452424bedb9feeefb6dfca8ffc687f59f2e75a0f66704f1501ec.json
+++ b/backend/.sqlx/query-1d52e5fb9a93452424bedb9feeefb6dfca8ffc687f59f2e75a0f66704f1501ec.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM state WHERE instance_id=$1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "state_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "instance_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "is_checkpoint",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "file_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "state_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "state_description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "screenshot_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "replay_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "creator_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 9,
+        "name": "state_replay_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "state_derived_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_on",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "save_derived_from",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "1d52e5fb9a93452424bedb9feeefb6dfca8ffc687f59f2e75a0f66704f1501ec"
+}

--- a/backend/.sqlx/query-29a639bd4ac9f760bd681b67693b101741dc95f57a71835bae506a8a58be5c53.json
+++ b/backend/.sqlx/query-29a639bd4ac9f760bd681b67693b101741dc95f57a71835bae506a8a58be5c53.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM replay WHERE instance_id=$1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "replay_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "replay_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "replay_description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "instance_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "creator_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "replay_forked_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "file_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_on",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "29a639bd4ac9f760bd681b67693b101741dc95f57a71835bae506a8a58be5c53"
+}

--- a/backend/.sqlx/query-acc785abf01c316f8c87e9c4f20f357c2e8ef4a941ab5858a032d23a2368f80a.json
+++ b/backend/.sqlx/query-acc785abf01c316f8c87e9c4f20f357c2e8ef4a941ab5858a032d23a2368f80a.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE state SET save_derived_from=$3 WHERE save_derived_from=$1 AND instance_id=$2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "acc785abf01c316f8c87e9c4f20f357c2e8ef4a941ab5858a032d23a2368f80a"
+}

--- a/backend/.sqlx/query-cabbba52ad32e63a5af0e38b88a37a3f932ebb610a5d1814e0de9aecf1fb7210.json
+++ b/backend/.sqlx/query-cabbba52ad32e63a5af0e38b88a37a3f932ebb610a5d1814e0de9aecf1fb7210.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM save WHERE instance_id=$1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "save_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "instance_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "save_short_desc",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "save_description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "file_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "creator_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_on",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "state_derived_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "save_derived_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 9,
+        "name": "replay_derived_from",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "cabbba52ad32e63a5af0e38b88a37a3f932ebb610a5d1814e0de9aecf1fb7210"
+}

--- a/backend/.sqlx/query-cea325da3800f723a0aa13231976e8c75f0a81a960dc11683560b8e6fb057ead.json
+++ b/backend/.sqlx/query-cea325da3800f723a0aa13231976e8c75f0a81a960dc11683560b8e6fb057ead.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO instance_save SELECT $3, $4 FROM instance_save WHERE instance_id=$1 AND save_id=$2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cea325da3800f723a0aa13231976e8c75f0a81a960dc11683560b8e6fb057ead"
+}

--- a/backend/.sqlx/query-fb07751297d95e9495580d58c32676a02d2305fb832f9cf37dd070be8eeea9b3.json
+++ b/backend/.sqlx/query-fb07751297d95e9495580d58c32676a02d2305fb832f9cf37dd070be8eeea9b3.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE replay SET replay_forked_from=$3 WHERE replay_forked_from=$2 AND instance_id=$1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fb07751297d95e9495580d58c32676a02d2305fb832f9cf37dd070be8eeea9b3"
+}

--- a/backend/gisst-cli/src/args.rs
+++ b/backend/gisst-cli/src/args.rs
@@ -140,8 +140,8 @@ pub struct UpgradeEnvironmentArgs {
     pub core_meta: String,
     /// Whether to destructively modify the environment or create
     /// cascading clones of environment, referring instances, etc.
-    #[arg(default_value_t = false)]
-    pub in_place: bool
+    #[arg(long = "in-place", default_value_t = false)]
+    pub in_place: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/backend/gisst-cli/src/args.rs
+++ b/backend/gisst-cli/src/args.rs
@@ -138,6 +138,10 @@ pub struct UpgradeEnvironmentArgs {
     /// file should be in the same directory as the other build
     /// outputs.
     pub core_meta: String,
+    /// Whether to destructively modify the environment or create
+    /// cascading clones of environment, referring instances, etc.
+    #[arg(default_value_t = false)]
+    pub in_place: bool
 }
 
 #[derive(Debug, Subcommand)]

--- a/backend/gisst-cli/src/main.rs
+++ b/backend/gisst-cli/src/main.rs
@@ -181,6 +181,7 @@ async fn upgrade_envs_by_clone(
             println!("Clone inst {old_inst_id} into {new_inst_id}");
             inst.instance_id = new_inst_id;
             inst.environment_id = new_id;
+            inst.created_on = now;
             inst.derived_from_instance = Some(old_inst_id);
             Instance::insert(&mut tx, inst, indexer).await?;
             // link objects to new instance; skip objects with name of any dependency in core_meta.dependencies
@@ -204,6 +205,7 @@ async fn upgrade_envs_by_clone(
                 replay.replay_id = Uuid::new_v4();
                 remapping.push((old_replay_id, replay.replay_id));
                 replay.instance_id = new_inst_id;
+                replay.created_on = now;
                 Replay::insert(&mut tx, replay, indexer).await?;
             }
             for (old_rid, new_rid) in remapping {
@@ -215,6 +217,7 @@ async fn upgrade_envs_by_clone(
                 state.state_id = Uuid::new_v4();
                 state.state_derived_from = Some(old_state_id);
                 state.instance_id = new_inst_id;
+                state.created_on = now;
                 State::insert(&mut tx, state, indexer).await?;
             }
             // save + instance_save
@@ -223,6 +226,7 @@ async fn upgrade_envs_by_clone(
                 save.save_id = Uuid::new_v4();
                 save.save_derived_from = Some(old_save_id);
                 save.instance_id = new_inst_id;
+                save.created_on = now;
                 sqlx::query!(r#"INSERT INTO instance_save SELECT $3, $4 FROM instance_save WHERE instance_id=$1 AND save_id=$2"#, old_inst_id, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
                 // fixup state->save links
                 sqlx::query!(r#"UPDATE state SET save_derived_from=$3 WHERE save_derived_from=$1 AND instance_id=$2"#, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;

--- a/backend/gisst-cli/src/main.rs
+++ b/backend/gisst-cli/src/main.rs
@@ -127,40 +127,35 @@ async fn main() -> Result<(), GISSTCliError> {
 }
 
 async fn upgrade_envs_in_place(
-    tx: &mut sqlx::PgConnection,
+    db: sqlx::PgPool,
     envs: Vec<Environment>,
     name: &str,
     core_hash: &str,
     deps: &[String],
-) -> Result<(Vec<Uuid>, Vec<Uuid>), GISSTCliError> {
+) -> Result<(), GISSTCliError> {
     use gisst::danger::{DestructiveEnvironment, DestructiveObject};
-    let changed_envs: Vec<_> = envs.iter().map(|e| e.environment_id).collect();
-    let mut changed_instances = vec![];
     println!("Replacing instanceobject links to files in {deps:?} with core file links...");
     for env in envs {
-        Environment::update_core(tx, env.environment_id, name, core_hash).await?;
-        let instances = Instance::get_all_for_environment_id(tx, env.environment_id).await?;
+        let mut tx = db.begin().await?;
+        Environment::update_core(&mut tx, env.environment_id, name, core_hash).await?;
+        let instances = Instance::get_all_for_environment_id(&mut tx, env.environment_id).await?;
         for inst in instances {
-            let mut changed = false;
             // delete dependency links of objects with name of any dependency in core_meta.dependencies
-            for link in ObjectLink::get_all_for_instance_id(tx, inst.instance_id).await? {
+            for link in ObjectLink::get_all_for_instance_id(&mut tx, inst.instance_id).await? {
                 if link.object_role == ObjectRole::Dependency && deps.contains(&link.file_filename)
                 {
                     // We can just unlink, the core offers the dependency now
-                    Object::unlink(tx, link.object_id, inst.instance_id).await?;
-                    changed = true;
+                    Object::unlink(&mut tx, link.object_id, inst.instance_id).await?;
                 }
             }
-            if changed {
-                changed_instances.push(inst.instance_id);
-            }
         }
+        tx.commit().await?;
     }
-    Ok((changed_envs, changed_instances))
+    Ok(())
 }
 
 async fn upgrade_envs_by_clone(
-    tx: &mut sqlx::PgConnection,
+    db: sqlx::PgPool,
     indexer: &gisst::search::MeiliIndexer,
     envs: Vec<Environment>,
     name: &str,
@@ -177,8 +172,9 @@ async fn upgrade_envs_by_clone(
         env.environment_core_name = name.to_string();
         env.environment_core_version = core_hash.to_string();
         env.created_on = now;
-        Environment::insert(tx, env).await?;
-        let instances = Instance::get_all_for_environment_id(tx, old_id).await?;
+        let mut tx = db.begin().await?;
+        Environment::insert(&mut tx, env).await?;
+        let instances = Instance::get_all_for_environment_id(&mut tx, old_id).await?;
         for mut inst in instances {
             let new_inst_id = Uuid::new_v4();
             let old_inst_id = inst.instance_id;
@@ -186,14 +182,14 @@ async fn upgrade_envs_by_clone(
             inst.instance_id = new_inst_id;
             inst.environment_id = new_id;
             inst.derived_from_instance = Some(old_inst_id);
-            Instance::insert(tx, inst, indexer).await?;
+            Instance::insert(&mut tx, inst, indexer).await?;
             // link objects to new instance; skip objects with name of any dependency in core_meta.dependencies
-            for link in ObjectLink::get_all_for_instance_id(tx, old_inst_id).await? {
+            for link in ObjectLink::get_all_for_instance_id(&mut tx, old_inst_id).await? {
                 if !(link.object_role == ObjectRole::Dependency
                     && deps.contains(&link.file_filename))
                 {
                     Object::link_object_to_instance(
-                        tx,
+                        &mut tx,
                         link.object_id,
                         new_inst_id,
                         link.object_role,
@@ -203,26 +199,26 @@ async fn upgrade_envs_by_clone(
                 }
             }
             let mut remapping = Vec::with_capacity(1024);
-            for mut replay in Replay::get_all_for_instance(tx, old_inst_id).await? {
+            for mut replay in Replay::get_all_for_instance(&mut tx, old_inst_id).await? {
                 let old_replay_id = replay.replay_id;
                 replay.replay_id = Uuid::new_v4();
                 remapping.push((old_replay_id, replay.replay_id));
                 replay.instance_id = new_inst_id;
-                Replay::insert(tx, replay, indexer).await?;
+                Replay::insert(&mut tx, replay, indexer).await?;
             }
             for (old_rid, new_rid) in remapping {
                 sqlx::query!(r#"UPDATE replay SET replay_forked_from=$3 WHERE replay_forked_from=$2 AND instance_id=$1"#, new_inst_id, old_rid, new_rid).execute(tx.as_mut()).await?;
             }
             // fixup replay fork relations
-            for mut state in State::get_all_for_instance(tx, old_inst_id).await? {
+            for mut state in State::get_all_for_instance(&mut tx, old_inst_id).await? {
                 let old_state_id = state.state_id;
                 state.state_id = Uuid::new_v4();
                 state.state_derived_from = Some(old_state_id);
                 state.instance_id = new_inst_id;
-                State::insert(tx, state, indexer).await?;
+                State::insert(&mut tx, state, indexer).await?;
             }
             // save + instance_save
-            for mut save in Save::get_all_for_instance(tx, old_inst_id).await? {
+            for mut save in Save::get_all_for_instance(&mut tx, old_inst_id).await? {
                 let old_save_id = save.save_id;
                 save.save_id = Uuid::new_v4();
                 save.save_derived_from = Some(old_save_id);
@@ -230,9 +226,10 @@ async fn upgrade_envs_by_clone(
                 sqlx::query!(r#"INSERT INTO instance_save SELECT $3, $4 FROM instance_save WHERE instance_id=$1 AND save_id=$2"#, old_inst_id, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
                 // fixup state->save links
                 sqlx::query!(r#"UPDATE state SET save_derived_from=$3 WHERE save_derived_from=$1 AND instance_id=$2"#, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
-                Save::insert(tx, save, indexer).await?;
+                Save::insert(&mut tx, save, indexer).await?;
             }
         }
+        tx.commit().await?;
     }
     Ok(())
 }
@@ -247,9 +244,9 @@ async fn upgrade_env(
     db: PgPool,
     indexer: &gisst::search::MeiliIndexer,
 ) -> Result<(), GISSTCliError> {
-    let mut tx = db.begin().await?;
+    let mut conn = db.acquire().await?;
     // find envs with core name and version
-    let envs = Environment::get_for_core(&mut tx, &old_core_name, &old_core_version).await?;
+    let envs = Environment::get_for_core(&mut conn, &old_core_name, &old_core_version).await?;
     if envs.is_empty() {
         println!("No environments using this core name were found.");
         return Ok(());
@@ -261,7 +258,7 @@ async fn upgrade_env(
     let core_meta: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(core_meta_path)?)?;
     let name = core_meta["core_name"].as_str().unwrap().to_string();
-    let Some(_) = Core::get(&mut tx, &name, core_hash).await? else {
+    let Some(_) = Core::get(&mut conn, &name, core_hash).await? else {
         println!(
             "Core {name}:{core_hash} is not present in the database, use gisst-cli add-core first"
         );
@@ -274,15 +271,12 @@ async fn upgrade_env(
         .filter_map(|x| x.as_str())
         .map(std::string::ToString::to_string)
         .collect();
+    drop(conn);
     if in_place {
-        let (changed_envs, changed_instances) =
-            upgrade_envs_in_place(&mut tx, envs, &name, core_hash, &deps).await?;
         println!("------DANGER ZONE-----");
         println!(
             "This command will apply irreversible changes!  Content will potentially be run on different cores if you haven't been very careful!"
         );
-        println!("Affected environments: {changed_envs:?}");
-        println!("Instances with changed objects: {changed_instances:?}");
         println!("Type 'yes' to confirm!");
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
@@ -291,10 +285,9 @@ async fn upgrade_env(
             return Ok(());
         }
         println!("Performing destructive changes!");
-        tx.commit().await?;
+        upgrade_envs_in_place(db, envs, &name, core_hash, &deps).await?;
     } else {
-        upgrade_envs_by_clone(&mut tx, indexer, envs, &name, core_hash, &deps).await?;
-        tx.commit().await?;
+        upgrade_envs_by_clone(db, indexer, envs, &name, core_hash, &deps).await?;
     }
     Ok(())
 }

--- a/backend/gisst-cli/src/main.rs
+++ b/backend/gisst-cli/src/main.rs
@@ -126,6 +126,117 @@ async fn main() -> Result<(), GISSTCliError> {
     Ok(())
 }
 
+async fn upgrade_envs_in_place(
+    tx: &mut sqlx::PgConnection,
+    envs: Vec<Environment>,
+    name: &str,
+    core_hash: &str,
+    deps: &[String],
+) -> Result<(Vec<Uuid>, Vec<Uuid>), GISSTCliError> {
+    use gisst::danger::{DestructiveEnvironment, DestructiveObject};
+    let changed_envs: Vec<_> = envs.iter().map(|e| e.environment_id).collect();
+    let mut changed_instances = vec![];
+    println!("Replacing instanceobject links to files in {deps:?} with core file links...");
+    for env in envs {
+        Environment::update_core(tx, env.environment_id, name, core_hash).await?;
+        let instances = Instance::get_all_for_environment_id(tx, env.environment_id).await?;
+        for inst in instances {
+            let mut changed = false;
+            // delete dependency links of objects with name of any dependency in core_meta.dependencies
+            for link in ObjectLink::get_all_for_instance_id(tx, inst.instance_id).await? {
+                if link.object_role == ObjectRole::Dependency && deps.contains(&link.file_filename)
+                {
+                    // We can just unlink, the core offers the dependency now
+                    Object::unlink(tx, link.object_id, inst.instance_id).await?;
+                    changed = true;
+                }
+            }
+            if changed {
+                changed_instances.push(inst.instance_id);
+            }
+        }
+    }
+    Ok((changed_envs, changed_instances))
+}
+
+async fn upgrade_envs_by_clone(
+    tx: &mut sqlx::PgConnection,
+    indexer: &gisst::search::MeiliIndexer,
+    envs: Vec<Environment>,
+    name: &str,
+    core_hash: &str,
+    deps: &[String],
+) -> Result<(), GISSTCliError> {
+    let now = chrono::Utc::now();
+    for mut env in envs {
+        let new_id = Uuid::new_v4();
+        let old_id = env.environment_id;
+        println!("Clone env {old_id} into {new_id}");
+        env.environment_derived_from = Some(old_id);
+        env.environment_id = new_id;
+        env.environment_core_name = name.to_string();
+        env.environment_core_version = core_hash.to_string();
+        env.created_on = now;
+        Environment::insert(tx, env).await?;
+        let instances = Instance::get_all_for_environment_id(tx, old_id).await?;
+        for mut inst in instances {
+            let new_inst_id = Uuid::new_v4();
+            let old_inst_id = inst.instance_id;
+            println!("Clone inst {old_inst_id} into {new_inst_id}");
+            inst.instance_id = new_inst_id;
+            inst.environment_id = new_id;
+            inst.derived_from_instance = Some(old_inst_id);
+            Instance::insert(tx, inst, indexer).await?;
+            // link objects to new instance; skip objects with name of any dependency in core_meta.dependencies
+            for link in ObjectLink::get_all_for_instance_id(tx, old_inst_id).await? {
+                if !(link.object_role == ObjectRole::Dependency
+                    && deps.contains(&link.file_filename))
+                {
+                    Object::link_object_to_instance(
+                        tx,
+                        link.object_id,
+                        new_inst_id,
+                        link.object_role,
+                        link.object_role_index.try_into()?,
+                    )
+                    .await?;
+                }
+            }
+            let mut remapping = Vec::with_capacity(1024);
+            for mut replay in Replay::get_all_for_instance(tx, old_inst_id).await? {
+                let old_replay_id = replay.replay_id;
+                replay.replay_id = Uuid::new_v4();
+                remapping.push((old_replay_id, replay.replay_id));
+                replay.instance_id = new_inst_id;
+                Replay::insert(tx, replay, indexer).await?;
+            }
+            for (old_rid, new_rid) in remapping {
+                sqlx::query!(r#"UPDATE replay SET replay_forked_from=$3 WHERE replay_forked_from=$2 AND instance_id=$1"#, new_inst_id, old_rid, new_rid).execute(tx.as_mut()).await?;
+            }
+            // fixup replay fork relations
+            for mut state in State::get_all_for_instance(tx, old_inst_id).await? {
+                let old_state_id = state.state_id;
+                state.state_id = Uuid::new_v4();
+                state.state_derived_from = Some(old_state_id);
+                state.instance_id = new_inst_id;
+                State::insert(tx, state, indexer).await?;
+            }
+            // save + instance_save
+            for mut save in Save::get_all_for_instance(tx, old_inst_id).await? {
+                let old_save_id = save.save_id;
+                save.save_id = Uuid::new_v4();
+                save.save_derived_from = Some(old_save_id);
+                save.instance_id = new_inst_id;
+                sqlx::query!(r#"INSERT INTO instance_save SELECT $3, $4 FROM instance_save WHERE instance_id=$1 AND save_id=$2"#, old_inst_id, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
+                // fixup state->save links
+                sqlx::query!(r#"UPDATE state SET save_derived_from=$3 WHERE save_derived_from=$1 AND instance_id=$2"#, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
+                Save::insert(tx, save, indexer).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn upgrade_env(
     UpgradeEnvironmentArgs {
         old_core_name,
@@ -163,32 +274,9 @@ async fn upgrade_env(
         .filter_map(|x| x.as_str())
         .map(std::string::ToString::to_string)
         .collect();
-    println!("Replacing instanceobject links to files in {deps:?} with core file links...");
-    let changed_envs: Vec<_> = envs.iter().map(|e| e.environment_id).collect();
-    let mut changed_instances = vec![];
     if in_place {
-        use gisst::danger::{DestructiveEnvironment, DestructiveObject};
-        for env in envs {
-            Environment::update_core(&mut tx, env.environment_id, &name, core_hash).await?;
-            let instances =
-                Instance::get_all_for_environment_id(&mut tx, env.environment_id).await?;
-            for inst in instances {
-                let mut changed = false;
-                // delete dependency links of objects with name of any dependency in core_meta.dependencies
-                for link in ObjectLink::get_all_for_instance_id(&mut tx, inst.instance_id).await? {
-                    if link.object_role == ObjectRole::Dependency
-                        && deps.contains(&link.file_filename)
-                    {
-                        // We can just unlink, the core offers the dependency now
-                        Object::unlink(&mut tx, link.object_id, inst.instance_id).await?;
-                        changed = true;
-                    }
-                }
-                if changed {
-                    changed_instances.push(inst.instance_id);
-                }
-            }
-        }
+        let (changed_envs, changed_instances) =
+            upgrade_envs_in_place(&mut tx, envs, &name, core_hash, &deps).await?;
         println!("------DANGER ZONE-----");
         println!(
             "This command will apply irreversible changes!  Content will potentially be run on different cores if you haven't been very careful!"
@@ -205,73 +293,7 @@ async fn upgrade_env(
         println!("Performing destructive changes!");
         tx.commit().await?;
     } else {
-        let now = chrono::Utc::now();
-        for mut env in envs {
-            let new_id = Uuid::new_v4();
-            let old_id = env.environment_id;
-            println!("Clone env {old_id} into {new_id}");
-            env.environment_derived_from = Some(old_id);
-            env.environment_id = new_id;
-            env.environment_core_name = name.clone();
-            env.environment_core_version = core_hash.to_string();
-            env.created_on = now;
-            Environment::insert(&mut tx, env).await?;
-            let instances = Instance::get_all_for_environment_id(&mut tx, old_id).await?;
-            for mut inst in instances {
-                let new_inst_id = Uuid::new_v4();
-                let old_inst_id = inst.instance_id;
-                println!("Clone inst {old_inst_id} into {new_inst_id}");
-                inst.instance_id = new_inst_id;
-                inst.environment_id = new_id;
-                inst.derived_from_instance = Some(old_inst_id);
-                Instance::insert(&mut tx, inst, indexer).await?;
-                // link objects to new instance; skip objects with name of any dependency in core_meta.dependencies
-                for link in ObjectLink::get_all_for_instance_id(&mut tx, old_inst_id).await? {
-                    if !(link.object_role == ObjectRole::Dependency
-                        && deps.contains(&link.file_filename))
-                    {
-                        Object::link_object_to_instance(
-                            &mut tx,
-                            link.object_id,
-                            new_inst_id,
-                            link.object_role,
-                            link.object_role_index.try_into()?,
-                        )
-                        .await?;
-                    }
-                }
-                let mut remapping = Vec::with_capacity(1024);
-                for mut replay in Replay::get_all_for_instance(&mut tx, old_inst_id).await? {
-                    let old_replay_id = replay.replay_id;
-                    replay.replay_id = Uuid::new_v4();
-                    remapping.push((old_replay_id, replay.replay_id));
-                    replay.instance_id = new_inst_id;
-                    Replay::insert(&mut tx, replay, indexer).await?;
-                }
-                for (old_rid, new_rid) in remapping {
-                    sqlx::query!(r#"UPDATE replay SET replay_forked_from=$3 WHERE replay_forked_from=$2 AND instance_id=$1"#, new_inst_id, old_rid, new_rid).execute(tx.as_mut()).await?;
-                }
-                // fixup replay fork relations
-                for mut state in State::get_all_for_instance(&mut tx, old_inst_id).await? {
-                    let old_state_id = state.state_id;
-                    state.state_id = Uuid::new_v4();
-                    state.state_derived_from = Some(old_state_id);
-                    state.instance_id = new_inst_id;
-                    State::insert(&mut tx, state, indexer).await?;
-                }
-                // save + instance_save
-                for mut save in Save::get_all_for_instance(&mut tx, old_inst_id).await? {
-                    let old_save_id = save.save_id;
-                    save.save_id = Uuid::new_v4();
-                    save.save_derived_from = Some(old_save_id);
-                    save.instance_id = new_inst_id;
-                    sqlx::query!(r#"INSERT INTO instance_save SELECT $3, $4 FROM instance_save WHERE instance_id=$1 AND save_id=$2"#, old_inst_id, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
-                    // fixup state->save links
-                    sqlx::query!(r#"UPDATE state SET save_derived_from=$3 WHERE save_derived_from=$1 AND instance_id=$2"#, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
-                    Save::insert(&mut tx, save, indexer).await?;
-                }
-            }
-        }
+        upgrade_envs_by_clone(&mut tx, indexer, envs, &name, core_hash, &deps).await?;
         tx.commit().await?;
     }
     Ok(())

--- a/backend/gisst-cli/src/main.rs
+++ b/backend/gisst-cli/src/main.rs
@@ -131,7 +131,7 @@ async fn upgrade_env(
         old_core_name,
         old_core_version,
         core_meta,
-        in_place
+        in_place,
     }: UpgradeEnvironmentArgs,
     db: PgPool,
     indexer: &gisst::search::MeiliIndexer,
@@ -167,65 +167,77 @@ async fn upgrade_env(
     let changed_envs: Vec<_> = envs.iter().map(|e| e.environment_id).collect();
     let mut changed_instances = vec![];
     if in_place {
-    use gisst::danger::{DestructiveEnvironment, DestructiveObject};
-    for env in envs {
-        Environment::update_core(&mut tx, env.environment_id, &name, core_hash).await?;
-        let instances = Instance::get_all_for_environment_id(&mut tx, env.environment_id).await?;
-        for inst in instances {
-            let mut changed = false;
-            // delete dependency links of objects with name of any dependency in core_meta.dependencies
-            for link in ObjectLink::get_all_for_instance_id(&mut tx, inst.instance_id).await? {
-                if link.object_role == ObjectRole::Dependency && deps.contains(&link.file_filename)
-                {
-                    // We can just unlink, the core offers the dependency now
-                    Object::unlink(&mut tx, link.object_id, inst.instance_id).await?;
-                    changed = true;
+        use gisst::danger::{DestructiveEnvironment, DestructiveObject};
+        for env in envs {
+            Environment::update_core(&mut tx, env.environment_id, &name, core_hash).await?;
+            let instances =
+                Instance::get_all_for_environment_id(&mut tx, env.environment_id).await?;
+            for inst in instances {
+                let mut changed = false;
+                // delete dependency links of objects with name of any dependency in core_meta.dependencies
+                for link in ObjectLink::get_all_for_instance_id(&mut tx, inst.instance_id).await? {
+                    if link.object_role == ObjectRole::Dependency
+                        && deps.contains(&link.file_filename)
+                    {
+                        // We can just unlink, the core offers the dependency now
+                        Object::unlink(&mut tx, link.object_id, inst.instance_id).await?;
+                        changed = true;
+                    }
+                }
+                if changed {
+                    changed_instances.push(inst.instance_id);
                 }
             }
-            if changed {
-                changed_instances.push(inst.instance_id);
-            }
         }
-    }
-    println!("------DANGER ZONE-----");
-    println!(
-        "This command will apply irreversible changes!  Content will potentially be run on different cores if you haven't been very careful!"
-    );
-    println!("Affected environments: {changed_envs:?}");
-    println!("Instances with changed objects: {changed_instances:?}");
-    println!("Type 'yes' to confirm!");
-    let mut input = String::new();
-    std::io::stdin().read_line(&mut input)?;
-    if input.trim() != "yes" {
-        println!("Aborting operation");
-        return Ok(());
-    }
-    println!("Performing destructive changes!");
-    tx.commit().await?;
+        println!("------DANGER ZONE-----");
+        println!(
+            "This command will apply irreversible changes!  Content will potentially be run on different cores if you haven't been very careful!"
+        );
+        println!("Affected environments: {changed_envs:?}");
+        println!("Instances with changed objects: {changed_instances:?}");
+        println!("Type 'yes' to confirm!");
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if input.trim() != "yes" {
+            println!("Aborting operation");
+            return Ok(());
+        }
+        println!("Performing destructive changes!");
+        tx.commit().await?;
     } else {
         let now = chrono::Utc::now();
         for mut env in envs {
             let new_id = Uuid::new_v4();
             let old_id = env.environment_id.clone();
+            println!("Clone env {old_id} into {new_id}");
             env.environment_derived_from = Some(old_id);
             env.environment_id = new_id;
             env.environment_core_name = name.clone();
             env.environment_core_version = core_hash.to_string();
             env.created_on = now;
             let env = Environment::insert(&mut tx, env).await?;
-            let instances = Instance::get_all_for_environment_id(&mut tx, env.environment_id).await?;
+            let instances = Instance::get_all_for_environment_id(&mut tx, old_id).await?;
             for mut inst in instances {
                 let new_inst_id = Uuid::new_v4();
                 let old_inst_id = inst.instance_id.clone();
+                println!("Clone inst {old_inst_id} into {new_inst_id}");
                 inst.instance_id = new_inst_id;
                 inst.environment_id = new_id;
                 inst.derived_from_instance = Some(old_inst_id);
                 Instance::insert(&mut tx, inst, indexer).await?;
                 // link objects to new instance; skip objects with name of any dependency in core_meta.dependencies
                 for link in ObjectLink::get_all_for_instance_id(&mut tx, old_inst_id).await? {
-                    if !(link.object_role == ObjectRole::Dependency && deps.contains(&link.file_filename))
+                    if !(link.object_role == ObjectRole::Dependency
+                        && deps.contains(&link.file_filename))
                     {
-                        Object::link_object_to_instance(&mut tx, link.object_id, new_inst_id, link.object_role, link.object_role_index.try_into()?).await?;
+                        Object::link_object_to_instance(
+                            &mut tx,
+                            link.object_id,
+                            new_inst_id,
+                            link.object_role,
+                            link.object_role_index.try_into()?,
+                        )
+                        .await?;
                     }
                 }
                 let mut remapping = Vec::with_capacity(1024);
@@ -260,7 +272,7 @@ async fn upgrade_env(
                 }
             }
         }
-
+        tx.commit().await?;
     }
     Ok(())
 }

--- a/backend/gisst-cli/src/main.rs
+++ b/backend/gisst-cli/src/main.rs
@@ -208,18 +208,18 @@ async fn upgrade_env(
         let now = chrono::Utc::now();
         for mut env in envs {
             let new_id = Uuid::new_v4();
-            let old_id = env.environment_id.clone();
+            let old_id = env.environment_id;
             println!("Clone env {old_id} into {new_id}");
             env.environment_derived_from = Some(old_id);
             env.environment_id = new_id;
             env.environment_core_name = name.clone();
             env.environment_core_version = core_hash.to_string();
             env.created_on = now;
-            let env = Environment::insert(&mut tx, env).await?;
+            Environment::insert(&mut tx, env).await?;
             let instances = Instance::get_all_for_environment_id(&mut tx, old_id).await?;
             for mut inst in instances {
                 let new_inst_id = Uuid::new_v4();
-                let old_inst_id = inst.instance_id.clone();
+                let old_inst_id = inst.instance_id;
                 println!("Clone inst {old_inst_id} into {new_inst_id}");
                 inst.instance_id = new_inst_id;
                 inst.environment_id = new_id;

--- a/backend/gisst-cli/src/main.rs
+++ b/backend/gisst-cli/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), GISSTCliError> {
         Commands::Reindex => reindex(db, &indexer).await?,
         Commands::RecalcSizes => recalc_sizes(db, &storage_root).await?,
         Commands::UpgradeEnvironment(args) => {
-            upgrade_env(args, db).await?;
+            upgrade_env(args, db, &indexer).await?;
         }
         Commands::AddCore(args) => {
             add_core(args, db, &storage_root).await?;
@@ -131,10 +131,11 @@ async fn upgrade_env(
         old_core_name,
         old_core_version,
         core_meta,
+        in_place
     }: UpgradeEnvironmentArgs,
     db: PgPool,
+    indexer: &gisst::search::MeiliIndexer,
 ) -> Result<(), GISSTCliError> {
-    use gisst::danger::{DestructiveEnvironment, DestructiveObject};
     let mut tx = db.begin().await?;
     // find envs with core name and version
     let envs = Environment::get_for_core(&mut tx, &old_core_name, &old_core_version).await?;
@@ -165,6 +166,8 @@ async fn upgrade_env(
     println!("Replacing instanceobject links to files in {deps:?} with core file links...");
     let changed_envs: Vec<_> = envs.iter().map(|e| e.environment_id).collect();
     let mut changed_instances = vec![];
+    if in_place {
+    use gisst::danger::{DestructiveEnvironment, DestructiveObject};
     for env in envs {
         Environment::update_core(&mut tx, env.environment_id, &name, core_hash).await?;
         let instances = Instance::get_all_for_environment_id(&mut tx, env.environment_id).await?;
@@ -191,14 +194,74 @@ async fn upgrade_env(
     println!("Affected environments: {changed_envs:?}");
     println!("Instances with changed objects: {changed_instances:?}");
     println!("Type 'yes' to confirm!");
-    let mut out = String::new();
-    std::io::stdin().read_line(&mut out)?;
-    if out.trim() != "yes" {
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    if input.trim() != "yes" {
         println!("Aborting operation");
         return Ok(());
     }
     println!("Performing destructive changes!");
     tx.commit().await?;
+    } else {
+        let now = chrono::Utc::now();
+        for mut env in envs {
+            let new_id = Uuid::new_v4();
+            let old_id = env.environment_id.clone();
+            env.environment_derived_from = Some(old_id);
+            env.environment_id = new_id;
+            env.environment_core_name = name.clone();
+            env.environment_core_version = core_hash.to_string();
+            env.created_on = now;
+            let env = Environment::insert(&mut tx, env).await?;
+            let instances = Instance::get_all_for_environment_id(&mut tx, env.environment_id).await?;
+            for mut inst in instances {
+                let new_inst_id = Uuid::new_v4();
+                let old_inst_id = inst.instance_id.clone();
+                inst.instance_id = new_inst_id;
+                inst.environment_id = new_id;
+                inst.derived_from_instance = Some(old_inst_id);
+                Instance::insert(&mut tx, inst, indexer).await?;
+                // link objects to new instance; skip objects with name of any dependency in core_meta.dependencies
+                for link in ObjectLink::get_all_for_instance_id(&mut tx, old_inst_id).await? {
+                    if !(link.object_role == ObjectRole::Dependency && deps.contains(&link.file_filename))
+                    {
+                        Object::link_object_to_instance(&mut tx, link.object_id, new_inst_id, link.object_role, link.object_role_index.try_into()?).await?;
+                    }
+                }
+                let mut remapping = Vec::with_capacity(1024);
+                for mut replay in Replay::get_all_for_instance(&mut tx, old_inst_id).await? {
+                    let old_replay_id = replay.replay_id;
+                    replay.replay_id = Uuid::new_v4();
+                    remapping.push((old_replay_id, replay.replay_id));
+                    replay.instance_id = new_inst_id;
+                    Replay::insert(&mut tx, replay, indexer).await?;
+                }
+                for (old_rid, new_rid) in remapping {
+                    sqlx::query!(r#"UPDATE replay SET replay_forked_from=$3 WHERE replay_forked_from=$2 AND instance_id=$1"#, new_inst_id, old_rid, new_rid).execute(tx.as_mut()).await?;
+                }
+                // fixup replay fork relations
+                for mut state in State::get_all_for_instance(&mut tx, old_inst_id).await? {
+                    let old_state_id = state.state_id;
+                    state.state_id = Uuid::new_v4();
+                    state.state_derived_from = Some(old_state_id);
+                    state.instance_id = new_inst_id;
+                    State::insert(&mut tx, state, indexer).await?;
+                }
+                // save + instance_save
+                for mut save in Save::get_all_for_instance(&mut tx, old_inst_id).await? {
+                    let old_save_id = save.save_id;
+                    save.save_id = Uuid::new_v4();
+                    save.save_derived_from = Some(old_save_id);
+                    save.instance_id = new_inst_id;
+                    sqlx::query!(r#"INSERT INTO instance_save SELECT $3, $4 FROM instance_save WHERE instance_id=$1 AND save_id=$2"#, old_inst_id, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
+                    // fixup state->save links
+                    sqlx::query!(r#"UPDATE state SET save_derived_from=$3 WHERE save_derived_from=$1 AND instance_id=$2"#, old_save_id, new_inst_id, save.save_id).execute(tx.as_mut()).await?;
+                    Save::insert(&mut tx, save, indexer).await?;
+                }
+            }
+        }
+
+    }
     Ok(())
 }
 

--- a/backend/gisst-server/src/server.rs
+++ b/backend/gisst-server/src/server.rs
@@ -195,6 +195,10 @@ pub async fn launch(config: &ServerConfig) -> Result<()> {
             builder.clone().service(selective_serve_dir::SelectiveServeDir::new("web-dist/ra")),
         )
         .nest_service(
+            "/cores",
+            builder.clone().service(selective_serve_dir::SelectiveServeDir::new("web-dist/cores")),
+        )
+        .nest_service(
             "/embed",
             builder.clone()
                 .service(selective_serve_dir::SelectiveServeDir::new("embed-dist")),

--- a/backend/gisst/src/models.rs
+++ b/backend/gisst/src/models.rs
@@ -637,6 +637,9 @@ impl Replay {
             .fetch_optional(conn)
             .await
     }
+    pub async fn get_all_for_instance(conn: &mut PgConnection, id:Uuid) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as!(Self, r#"SELECT * FROM replay WHERE instance_id=$1"#, id).fetch_all(conn).await
+    }
 
     pub async fn insert(
         conn: &mut PgConnection,
@@ -672,6 +675,9 @@ impl Save {
         sqlx::query_as!(Self, r#"SELECT * FROM save WHERE save_id = $1"#, id)
             .fetch_optional(conn)
             .await
+    }
+    pub async fn get_all_for_instance(conn: &mut PgConnection, id:Uuid) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as!(Self, r#"SELECT * FROM save WHERE instance_id=$1"#, id).fetch_all(conn).await
     }
     pub async fn insert(
         conn: &mut PgConnection,
@@ -774,6 +780,10 @@ impl State {
         sqlx::query_as!(Self, r#"SELECT * FROM state WHERE state_id = $1"#, id,)
             .fetch_optional(conn)
             .await
+    }
+
+    pub async fn get_all_for_instance(conn: &mut PgConnection, id:Uuid) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as!(Self, r#"SELECT * FROM state WHERE instance_id=$1"#, id).fetch_all(conn).await
     }
 
     pub async fn insert(

--- a/backend/gisst/src/models.rs
+++ b/backend/gisst/src/models.rs
@@ -637,8 +637,13 @@ impl Replay {
             .fetch_optional(conn)
             .await
     }
-    pub async fn get_all_for_instance(conn: &mut PgConnection, id:Uuid) -> sqlx::Result<Vec<Self>> {
-        sqlx::query_as!(Self, r#"SELECT * FROM replay WHERE instance_id=$1"#, id).fetch_all(conn).await
+    pub async fn get_all_for_instance(
+        conn: &mut PgConnection,
+        id: Uuid,
+    ) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as!(Self, r#"SELECT * FROM replay WHERE instance_id=$1"#, id)
+            .fetch_all(conn)
+            .await
     }
 
     pub async fn insert(
@@ -676,8 +681,13 @@ impl Save {
             .fetch_optional(conn)
             .await
     }
-    pub async fn get_all_for_instance(conn: &mut PgConnection, id:Uuid) -> sqlx::Result<Vec<Self>> {
-        sqlx::query_as!(Self, r#"SELECT * FROM save WHERE instance_id=$1"#, id).fetch_all(conn).await
+    pub async fn get_all_for_instance(
+        conn: &mut PgConnection,
+        id: Uuid,
+    ) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as!(Self, r#"SELECT * FROM save WHERE instance_id=$1"#, id)
+            .fetch_all(conn)
+            .await
     }
     pub async fn insert(
         conn: &mut PgConnection,
@@ -782,8 +792,13 @@ impl State {
             .await
     }
 
-    pub async fn get_all_for_instance(conn: &mut PgConnection, id:Uuid) -> sqlx::Result<Vec<Self>> {
-        sqlx::query_as!(Self, r#"SELECT * FROM state WHERE instance_id=$1"#, id).fetch_all(conn).await
+    pub async fn get_all_for_instance(
+        conn: &mut PgConnection,
+        id: Uuid,
+    ) -> sqlx::Result<Vec<Self>> {
+        sqlx::query_as!(Self, r#"SELECT * FROM state WHERE instance_id=$1"#, id)
+            .fetch_all(conn)
+            .await
     }
 
     pub async fn insert(

--- a/frontend/frontend-embed/src/ra.ts
+++ b/frontend/frontend-embed/src/ra.ts
@@ -2,15 +2,19 @@ import {ColdStart, StateStart, ReplayStart, CoreFileLink, ObjectLink, EmuControl
 import {loadRetroArch,LibretroModule} from './libretro_adapter';
 
 export async function init(gisst_root:string, core:string, start:ColdStart | StateStart | ReplayStart, saves:SaveFileLink[], core_manifest:CoreFileLink[], manifest:ObjectLink[], container:HTMLDivElement, embed_options:EmbedOptions):Promise<EmuControls> {
-  const state_dir = "/mem/states";
-  const saves_dir = "/mem/saves";
-  const retro_args = ["-v"];
-  const content = manifest.find((o) => o.object_role=="content" && o.object_role_index == 0)!;
-    const core_path = 'storage/'+core_manifest.find((o) => o.core_role=="entrypoint" && o.core_role_index == 0)!.file_dest_path;
+    const state_dir = "/mem/states";
+    const saves_dir = "/mem/saves";
+    const retro_args = ["-v"];
+    const content = manifest.find((o) => o.object_role=="content" && o.object_role_index == 0)!;
+    const core_entry = core_manifest.find((o) => o.core_role=="entrypoint" && o.core_role_index == 0);
+    const core_path = core_entry ? 'storage/'+core_entry.file_dest_path : 'cores/'+core+'_libretro.js';
     const remote_deps:{[id:string]:string} = {};
     const core_config = core_manifest.find((o) => o.core_role=="config");
     const instance_config = manifest.find((o) => o.object_role=="config");
     const extra_configs:string[] = [];
+    if (!core_entry) {
+        remote_deps[core+'_libretro.wasm'] = 'cores/'+core+'_libretro.wasm';
+    }
     if (core_config) {
         extra_configs.push(core_config.file_dest_path);
     }

--- a/frontend/frontend-web/src/ra.ts
+++ b/frontend/frontend-web/src/ra.ts
@@ -21,11 +21,15 @@ let content_base:string;
 
 export async function init(gisst_root:string, core:string, start:ColdStart | StateStart | ReplayStart, saves:GISSTModels.SaveFileLink[], core_manifest:CoreFileLink[], manifest:ObjectLink[], boot_into_record:boolean, embed_options:EmbedOptions) {
     db = new GISSTDBConnector(gisst_root);
-    const core_path = 'storage/'+core_manifest.find((o) => o.core_role=="entrypoint" && o.core_role_index == 0)!.file_dest_path;
+    const core_entry = core_manifest.find((o) => o.core_role=="entrypoint" && o.core_role_index == 0);
+    const core_path = core_entry ? 'storage/'+core_entry.file_dest_path : 'cores/'+core+'_libretro.js';
     const remote_deps:{[id:string]:string} = {};
     const core_config = core_manifest.find((o) => o.core_role=="config");
     const instance_config = manifest.find((o) => o.object_role=="config");
     const extra_configs:string[] = [];
+    if (!core_entry) {
+        remote_deps[core+'_libretro.wasm'] = 'cores/'+core+'_libretro.wasm';
+    }
     if (core_config) {
         extra_configs.push(core_config.file_dest_path);
     }


### PR DESCRIPTION
If you have a database with a bunch of states, saves, instances using old cores, you should run something like this for each old core to clone all the states, saves, instances with new environments referencing the new core.

This will clone *every* environment which used the old core name and version (this is important to note because e.g. ingest makes a new environment for each work; was that a good idea? IDK), and for each cloned environment it will clone all instances, states, saves, etc referring to the original.