### PR TITLE
Explicitly ask for chd support in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
     "repo": "https://github.com/libretro/retroarch",
     "version": "ee96a134660b4dfdce2bef8457a7e76c29b4d021",
     "build_args": [
+      "HAVE_CHD=1",
       "HAVE_RWEBAUDIO=0",
       "HAVE_THREADS=1",
       "PTHREAD_POOL_SIZE=4",


### PR DESCRIPTION
I think this is the default in the makefile but it should be explicit.